### PR TITLE
To avoid SCRIPT1010: Expected identifier in IE < 9

### DIFF
--- a/bootstrap-tree/js/bootstrap-tree.js
+++ b/bootstrap-tree/js/bootstrap-tree.js
@@ -156,7 +156,7 @@
           
           var branch = $("<ul>").addClass("branch")
           
-          attributes.class = "tree-toggle closed"
+          attributes["class"] = "tree-toggle closed"
           attributes["data-toggle"] = "branch"
             
         }


### PR DESCRIPTION
While trying Bootstrap-Tree out in IE10 developer mode emulating IE8 (lowest IE version supported by our project) I noticed that IE was throwing an error: SCRIPT1010: Expected identifier. It happened due to the dot notation for the attributes variable. Changed it to bracket notation and it worked like a charm.

This is my first edit on project that isn't my own, so I apologize if I am doing something incorrect. =)
