### PR TITLE
quote keyword 'class' to satisfy yui compressor

### DIFF
--- a/bootstrap-tree/js/bootstrap-tree.js
+++ b/bootstrap-tree/js/bootstrap-tree.js
@@ -156,7 +156,7 @@
           
           var branch = $("<ul>").addClass("branch")
           
-          attributes.class = "tree-toggle closed"
+          attributes["class"] = "tree-toggle closed"
           attributes["data-toggle"] = "branch"
             
         }


### PR DESCRIPTION
yui compressor with 2.4.8 or 2.4.6 can not compress bootstrap-tree.js... hotfix in this PR. review plz. thx.
